### PR TITLE
Allow administrator to blacklist an email

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ setono_sylius_trustpilot:
     resource: "@SetonoSyliusTrustpilotPlugin/Resources/config/routes.yaml"
 ```
 
+### Install assets
+
+```bash
+bin/console assets:install
+```
+
 ### Update your schema
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,10 @@
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
         "symfony/form": "^4.4 || ^5.4 || ^6.0",
         "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
         "symfony/messenger": "^4.4 || ^5.4 || ^6.0",
         "symfony/options-resolver": "^4.4 || ^5.4 || ^6.0",
+        "symfony/routing": "^4.4 || ^5.4 || ^6.0",
+        "symfony/translation-contracts": "^2.5 || ^3.1",
         "symfony/workflow": "^4.4 || ^5.4 || ^6.0",
         "twig/twig": "^2.15",
         "webmozart/assert": "^1.11"

--- a/src/Controller/Action/BlacklistCustomerAction.php
+++ b/src/Controller/Action/BlacklistCustomerAction.php
@@ -4,39 +4,118 @@ declare(strict_types=1);
 
 namespace Setono\SyliusTrustpilotPlugin\Controller\Action;
 
+use InvalidArgumentException;
+use Setono\SyliusTrustpilotPlugin\Factory\BlacklistedCustomerFactoryInterface;
+use Setono\SyliusTrustpilotPlugin\Repository\BlacklistedCustomerRepositoryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 
-// todo
 final class BlacklistCustomerAction
 {
     private CustomerRepositoryInterface $customerRepository;
 
-    public function __construct(CustomerRepositoryInterface $customerRepository)
-    {
+    private BlacklistedCustomerRepositoryInterface $blacklistedCustomerRepository;
+
+    private BlacklistedCustomerFactoryInterface $blacklistedCustomerFactory;
+
+    private TranslatorInterface $translator;
+
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(
+        CustomerRepositoryInterface $customerRepository,
+        BlacklistedCustomerRepositoryInterface $blacklistedCustomerRepository,
+        BlacklistedCustomerFactoryInterface $blacklistedCustomerFactory,
+        TranslatorInterface $translator,
+        UrlGeneratorInterface $urlGenerator
+    ) {
         $this->customerRepository = $customerRepository;
+        $this->blacklistedCustomerRepository = $blacklistedCustomerRepository;
+        $this->blacklistedCustomerFactory = $blacklistedCustomerFactory;
+        $this->translator = $translator;
+        $this->urlGenerator = $urlGenerator;
     }
 
     public function __invoke(Request $request): Response
     {
-        /** @var mixed $customerId */
-        $customerId = $request->query->get('customerId');
-        if (!is_string($customerId) || '' === $customerId) {
-            // todo should not be this exception, but it works for now
-            throw new NotFoundHttpException('You need to provide a customer id to blacklist');
+        try {
+            $email = $this->resolveEmail($request);
+        } catch (InvalidArgumentException $e) {
+            $this->addFlash($request, 'error', $e->getMessage());
+
+            return new RedirectResponse($this->resolveRedirectUrl($request));
         }
 
+        $blacklistedCustomer = $this->blacklistedCustomerRepository->findOneByEmail($email);
+        if (null === $blacklistedCustomer) {
+            $blacklistedCustomer = $this->blacklistedCustomerFactory->createWithEmail($email);
+            $this->blacklistedCustomerRepository->add($blacklistedCustomer);
+        }
+
+        $this->addFlash(
+            $request,
+            'success',
+            $this->translator->trans('setono_sylius_trustpilot.blacklisted_customer.blacklisted', ['%email%' => $email], 'flashes')
+        );
+
+        return new RedirectResponse($this->resolveRedirectUrl($request));
+    }
+
+    private function resolveEmail(Request $request): string
+    {
+        /** @var mixed $email */
+        $email = $request->query->get('email') ?? $request->request->get('email');
+        if (is_string($email) && '' !== $email) {
+            return $email;
+        }
+
+        /** @var mixed $customerId */
+        $customerId = $request->query->get('customerId') ?? $request->request->get('customerId');
+        if (!is_string($customerId) || '' === $customerId) {
+            throw new InvalidArgumentException(sprintf(
+                'To blacklist an email you either need to add a customerId parameter or an email parameter, i.e. %s',
+                $this->urlGenerator->generate('setono_sylius_trustpilot_admin_blacklist_customer', ['email' => 'johndoe@example.com'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ));
+        }
+
+        /** @var CustomerInterface|object|null $customer */
         $customer = $this->customerRepository->find($customerId);
         Assert::nullOrIsInstanceOf($customer, CustomerInterface::class);
 
         if (null === $customer) {
-            throw new NotFoundHttpException(sprintf('The customer with id %s does not exist', $customerId));
+            throw new InvalidArgumentException(sprintf('The customer with id %s does not exist', $customerId));
         }
 
-        return new Response();
+        $email = $customer->getEmailCanonical();
+        Assert::notNull($email);
+
+        return $email;
+    }
+
+    private function addFlash(Request $request, string $type, string $message): void
+    {
+        $session = $request->getSession();
+
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        if ($session instanceof Session) {
+            $session->getFlashBag()->add($type, $message);
+        }
+    }
+
+    private function resolveRedirectUrl(Request $request): string
+    {
+        $referrer = $request->headers->get('referer');
+        if (is_string($referrer) && '' !== $referrer) {
+            return $referrer;
+        }
+
+        return $this->urlGenerator->generate('setono_sylius_trustpilot_admin_invitation_index');
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterInvitationEligibilityCheckersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterInvitationEligibilityCheckersPass.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RegisterInvitationEligibilityCheckersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('setono_sylius_trustpilot.invitation_eligibility_checker.composite')) {
+            return;
+        }
+
+        $composite = $container->getDefinition('setono_sylius_trustpilot.invitation_eligibility_checker.composite');
+
+        /** @var string $id */
+        foreach (array_keys($container->findTaggedServiceIds('setono_sylius_trustpilot.invitation_eligibility_checker')) as $id) {
+            $composite->addMethodCall('add', [new Reference($id)]);
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Setono\SyliusTrustpilotPlugin\DependencyInjection;
 
 use Setono\SyliusTrustpilotPlugin\Form\Type\ChannelConfigurationType;
+use Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomer;
 use Setono\SyliusTrustpilotPlugin\Model\ChannelConfiguration;
 use Setono\SyliusTrustpilotPlugin\Model\Invitation;
+use Setono\SyliusTrustpilotPlugin\Repository\BlacklistedCustomerRepository;
 use Setono\SyliusTrustpilotPlugin\Repository\ChannelConfigurationRepository;
 use Setono\SyliusTrustpilotPlugin\Repository\InvitationRepository;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
@@ -44,6 +46,22 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('resources')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->arrayNode('blacklisted_customer')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(BlacklistedCustomer::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->defaultValue(BlacklistedCustomerRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('form')->defaultValue(DefaultResourceType::class)->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
                         ->arrayNode('channel_configuration')
                             ->addDefaultsIfNotSet()
                             ->children()

--- a/src/EligibilityChecker/BlacklistedCustomerInvitationEligibilityChecker.php
+++ b/src/EligibilityChecker/BlacklistedCustomerInvitationEligibilityChecker.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\EligibilityChecker;
+
+use Setono\SyliusTrustpilotPlugin\Model\InvitationInterface;
+use Setono\SyliusTrustpilotPlugin\Repository\BlacklistedCustomerRepositoryInterface;
+
+final class BlacklistedCustomerInvitationEligibilityChecker implements InvitationEligibilityCheckerInterface
+{
+    private BlacklistedCustomerRepositoryInterface $blacklistedCustomerRepository;
+
+    public function __construct(BlacklistedCustomerRepositoryInterface $blacklistedCustomerRepository)
+    {
+        $this->blacklistedCustomerRepository = $blacklistedCustomerRepository;
+    }
+
+    public function check(InvitationInterface $invitation): EligibilityCheck
+    {
+        $email = $invitation->getEmail();
+
+        return null !== $email && $this->blacklistedCustomerRepository->isBlacklisted($email) ?
+            new EligibilityCheck(false, sprintf('The email %s is blacklisted', $email)) : new EligibilityCheck(true);
+    }
+}

--- a/src/EligibilityChecker/CompositeInvitationEligibilityChecker.php
+++ b/src/EligibilityChecker/CompositeInvitationEligibilityChecker.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\EligibilityChecker;
+
+use Setono\SyliusTrustpilotPlugin\Model\InvitationInterface;
+
+final class CompositeInvitationEligibilityChecker implements InvitationEligibilityCheckerInterface
+{
+    /** @var list<InvitationEligibilityCheckerInterface> */
+    private array $checkers = [];
+
+    public function add(InvitationEligibilityCheckerInterface $invitationEligibilityChecker): void
+    {
+        $this->checkers[] = $invitationEligibilityChecker;
+    }
+
+    public function check(InvitationInterface $invitation): EligibilityCheck
+    {
+        $eligible = true;
+        $reasons = [];
+
+        foreach ($this->checkers as $checker) {
+            $check = $checker->check($invitation);
+            if (!$check->eligible) {
+                $eligible = false;
+                $reasons[] = $check->reasons;
+            }
+        }
+
+        return new EligibilityCheck($eligible, array_merge(...$reasons));
+    }
+}

--- a/src/EligibilityChecker/EligibilityCheck.php
+++ b/src/EligibilityChecker/EligibilityCheck.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\EligibilityChecker;
+
+use Webmozart\Assert\Assert;
+
+final class EligibilityCheck
+{
+    public bool $eligible;
+
+    /** @var list<string> */
+    public array $reasons;
+
+    /**
+     * @param string|list<string> $reasons
+     */
+    public function __construct(bool $eligible, $reasons = [])
+    {
+        if (is_string($reasons)) {
+            $reasons = [$reasons];
+        }
+
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        Assert::isArray($reasons);
+
+        $this->eligible = $eligible;
+        $this->reasons = $reasons;
+    }
+}

--- a/src/EligibilityChecker/InvitationEligibilityCheckerInterface.php
+++ b/src/EligibilityChecker/InvitationEligibilityCheckerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\EligibilityChecker;
+
+use Setono\SyliusTrustpilotPlugin\Model\InvitationInterface;
+
+interface InvitationEligibilityCheckerInterface
+{
+    public function check(InvitationInterface $invitation): EligibilityCheck;
+}

--- a/src/Factory/BlacklistedCustomerFactory.php
+++ b/src/Factory/BlacklistedCustomerFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\Factory;
+
+use Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomerInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Webmozart\Assert\Assert;
+
+final class BlacklistedCustomerFactory implements BlacklistedCustomerFactoryInterface
+{
+    private FactoryInterface $decorated;
+
+    public function __construct(FactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public function createNew(): BlacklistedCustomerInterface
+    {
+        /** @var object|BlacklistedCustomerInterface $obj */
+        $obj = $this->decorated->createNew();
+        Assert::isInstanceOf($obj, BlacklistedCustomerInterface::class);
+
+        return $obj;
+    }
+
+    public function createWithEmail(string $email): BlacklistedCustomerInterface
+    {
+        $obj = $this->createNew();
+        $obj->setEmail($email);
+
+        return $obj;
+    }
+}

--- a/src/Factory/BlacklistedCustomerFactoryInterface.php
+++ b/src/Factory/BlacklistedCustomerFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\Factory;
+
+use Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomerInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+interface BlacklistedCustomerFactoryInterface extends FactoryInterface
+{
+    public function createNew(): BlacklistedCustomerInterface;
+
+    public function createWithEmail(string $email): BlacklistedCustomerInterface;
+}

--- a/src/Model/BlacklistedCustomer.php
+++ b/src/Model/BlacklistedCustomer.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\Model;
+
+use Sylius\Component\Resource\Model\TimestampableTrait;
+
+class BlacklistedCustomer implements BlacklistedCustomerInterface
+{
+    use TimestampableTrait;
+
+    protected ?int $id = null;
+
+    protected ?string $email = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+}

--- a/src/Model/BlacklistedCustomerInterface.php
+++ b/src/Model/BlacklistedCustomerInterface.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Setono\SyliusTrustpilotPlugin\Model;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
-interface BlacklistedCustomerInterface extends TimestampableInterface
+interface BlacklistedCustomerInterface extends ResourceInterface, TimestampableInterface
 {
+    public function getId(): ?int;
+
     public function getEmail(): ?string;
 
     public function setEmail(string $email): void;

--- a/src/Model/Invitation.php
+++ b/src/Model/Invitation.php
@@ -68,6 +68,13 @@ class Invitation implements InvitationInterface
         $this->processingErrors[] = $processingError;
     }
 
+    public function addProcessingErrors(array $processingErrors): void
+    {
+        foreach ($processingErrors as $processingError) {
+            $this->addProcessingError($processingError);
+        }
+    }
+
     public function getOrder(): ?OrderInterface
     {
         return $this->order;
@@ -103,8 +110,33 @@ class Invitation implements InvitationInterface
         return $this->getState() === InvitationWorkflow::STATE_PENDING;
     }
 
+    public function isFailed(): bool
+    {
+        return $this->getState() === InvitationWorkflow::STATE_FAILED;
+    }
+
+    public function isIneligible(): bool
+    {
+        return $this->getState() === InvitationWorkflow::STATE_INELIGIBLE;
+    }
+
     public function isDeletable(): bool
     {
         return $this->getState() !== InvitationWorkflow::STATE_SENT;
+    }
+
+    public function getEmail(): ?string
+    {
+        $order = $this->getOrder();
+        if (null === $order) {
+            return null;
+        }
+
+        $customer = $order->getCustomer();
+        if (null === $customer) {
+            return null;
+        }
+
+        return $customer->getEmailCanonical();
     }
 }

--- a/src/Model/InvitationInterface.php
+++ b/src/Model/InvitationInterface.php
@@ -30,6 +30,11 @@ interface InvitationInterface extends ResourceInterface, TimestampableInterface,
 
     public function addProcessingError(string $processingError): void;
 
+    /**
+     * @param list<string> $processingErrors
+     */
+    public function addProcessingErrors(array $processingErrors): void;
+
     public function getOrder(): ?OrderInterface;
 
     public function setOrder(OrderInterface $order): void;
@@ -47,8 +52,14 @@ interface InvitationInterface extends ResourceInterface, TimestampableInterface,
      */
     public function isPending(): bool;
 
+    public function isFailed(): bool;
+
+    public function isIneligible(): bool;
+
     /**
      * Returns true if the invitation is deletable
      */
     public function isDeletable(): bool;
+
+    public function getEmail(): ?string;
 }

--- a/src/Repository/BlacklistedCustomerRepository.php
+++ b/src/Repository/BlacklistedCustomerRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\Repository;
+
+use Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomerInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Webmozart\Assert\Assert;
+
+class BlacklistedCustomerRepository extends EntityRepository implements BlacklistedCustomerRepositoryInterface
+{
+    public function findOneByEmail(string $email): ?BlacklistedCustomerInterface
+    {
+        $obj = $this->createQueryBuilder('o')
+            ->andWhere('o.email = :email')
+            ->setParameter('email', $email)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+
+        Assert::nullOrIsInstanceOf($obj, BlacklistedCustomerInterface::class);
+
+        return $obj;
+    }
+
+    public function isBlacklisted(string $email): bool
+    {
+        return $this->findOneByEmail($email) !== null;
+    }
+}

--- a/src/Repository/BlacklistedCustomerRepositoryInterface.php
+++ b/src/Repository/BlacklistedCustomerRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusTrustpilotPlugin\Repository;
+
+use Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomerInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+interface BlacklistedCustomerRepositoryInterface extends RepositoryInterface
+{
+    public function findOneByEmail(string $email): ?BlacklistedCustomerInterface;
+
+    public function isBlacklisted(string $email): bool;
+}

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -13,6 +13,11 @@ sylius_mailer:
             subject: setono_sylius_trustpilot.emails.trustpilot.subject
             template: "@SetonoSyliusTrustpilotPlugin/email/trustpilot.html.twig"
 
+sylius_grid:
+    templates:
+        action:
+            blacklist_customer: "@SetonoSyliusTrustpilotPlugin/admin/grid/action/blacklist_customer.html.twig"
+
 sylius_ui:
     events:
         setono_sylius_trustpilot.admin.invitation.index:
@@ -20,3 +25,7 @@ sylius_ui:
                 missing_channel_configurations:
                     template: "@SetonoSyliusTrustpilotPlugin/admin/block/_missing_channel_configurations.html.twig"
                     priority: 11
+        setono_sylius_trustpilot.admin.invitation.index.javascripts:
+            blocks:
+                javascript_popup:
+                    template: "@SetonoSyliusTrustpilotPlugin/admin/block/_javascript_popup.html.twig"

--- a/src/Resources/config/doctrine/model/BlacklistedCustomer.orm.xml
+++ b/src/Resources/config/doctrine/model/BlacklistedCustomer.orm.xml
@@ -1,0 +1,19 @@
+<doctrine-mapping xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+                  xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+    <mapped-superclass name="Setono\SyliusTrustpilotPlugin\Model\BlacklistedCustomer"
+                       table="setono_sylius_trustpilot__blacklisted_customer">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="email" unique="true"/>
+
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
+            <gedmo:timestampable on="update"/>
+        </field>
+    </mapped-superclass>
+</doctrine-mapping>

--- a/src/Resources/config/grids/setono_sylius_trustpilot_admin_invitation.yaml
+++ b/src/Resources/config/grids/setono_sylius_trustpilot_admin_invitation.yaml
@@ -28,6 +28,7 @@ sylius_grid:
                 state:
                     type: twig
                     label: setono_sylius_trustpilot.ui.state
+                    path: .
                     options:
                         template: "@SetonoSyliusTrustpilotPlugin/admin/grid/label/invitation_state.html.twig"
                 sentAt:
@@ -44,3 +45,12 @@ sylius_grid:
                         options:
                             link:
                                 route: setono_sylius_trustpilot_admin_channel_configuration_index
+                item:
+                    blacklist_customer:
+                        type: blacklist_customer
+                        label: setono_sylius_trustpilot.ui.blacklist_customer
+                        options:
+                            link:
+                                route: setono_sylius_trustpilot_admin_blacklist_customer
+                                parameters:
+                                    email: resource.email

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -23,3 +23,11 @@ setono_sylius_trustpilot_admin_invitation:
             index:
                 icon: 'star'
     type: sylius.resource
+
+setono_sylius_trustpilot_admin_blacklist_customer:
+    path: /blacklist-customer
+    methods: [ GET, POST ]
+    defaults:
+        _controller: setono_sylius_trustpilot.controller.action.blacklist_customer
+        _sylius:
+            section: admin

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <import resource="services/command.xml"/>
         <import resource="services/controller.xml"/>
         <import resource="services/dispatcher.xml"/>
+        <import resource="services/eligibility_checker.xml"/>
         <import resource="services/event_subscriber.xml"/>
         <import resource="services/factory.xml"/>
         <import resource="services/form.xml"/>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -6,6 +6,17 @@
     <services>
         <defaults public="true"/>
 
+        <service id="setono_sylius_trustpilot.controller.action.blacklist_customer"
+                 class="Setono\SyliusTrustpilotPlugin\Controller\Action\BlacklistCustomerAction">
+            <argument type="service" id="sylius.repository.customer"/>
+            <argument type="service" id="setono_sylius_trustpilot.repository.blacklisted_customer"/>
+            <argument type="service" id="setono_sylius_trustpilot.factory.blacklisted_customer"/>
+            <argument type="service" id="translator"/>
+            <argument type="service" id="router"/>
+
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="setono_sylius_trustpilot.controller.action.render_missing_channel_configurations"
                  class="Setono\SyliusTrustpilotPlugin\Controller\Action\RenderMissingChannelConfigurationsAction">
             <argument type="service" id="setono_sylius_trustpilot.repository.channel_configuration"/>

--- a/src/Resources/config/services/eligibility_checker.xml
+++ b/src/Resources/config/services/eligibility_checker.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_sylius_trustpilot.invitation_eligibility_checker.composite"
+                 class="Setono\SyliusTrustpilotPlugin\EligibilityChecker\CompositeInvitationEligibilityChecker">
+        </service>
+
+        <service id="setono_sylius_trustpilot.invitation_eligibility_checker.blacklisted_customer"
+                 class="Setono\SyliusTrustpilotPlugin\EligibilityChecker\BlacklistedCustomerInvitationEligibilityChecker">
+            <argument type="service" id="setono_sylius_trustpilot.repository.blacklisted_customer"/>
+
+            <tag name="setono_sylius_trustpilot.invitation_eligibility_checker"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/factory.xml
+++ b/src/Resources/config/services/factory.xml
@@ -9,5 +9,11 @@
                  decorates="setono_sylius_trustpilot.factory.invitation">
             <argument type="service" id="setono_sylius_trustpilot.custom_factory.invitation.inner"/>
         </service>
+
+        <service id="setono_sylius_trustpilot.custom_factory.blacklisted_customer"
+                 class="Setono\SyliusTrustpilotPlugin\Factory\BlacklistedCustomerFactory" decoration-priority="64"
+                 decorates="setono_sylius_trustpilot.factory.blacklisted_customer">
+            <argument type="service" id="setono_sylius_trustpilot.custom_factory.blacklisted_customer.inner"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/processor.xml
+++ b/src/Resources/config/services/processor.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="setono_sylius_trustpilot.mailer.email_manager"/>
             <argument type="service" id="workflow.registry"/>
             <argument type="service" id="setono_sylius_trustpilot.repository.channel_configuration"/>
+            <argument type="service" id="setono_sylius_trustpilot.invitation_eligibility_checker.composite"/>
         </service>
     </services>
 </container>

--- a/src/Resources/public/setono-sylius-gift-card-popup.js
+++ b/src/Resources/public/setono-sylius-gift-card-popup.js
@@ -1,0 +1,3 @@
+(function ($) {
+    $('.invitation-state.invitation-popup').popup();
+})(jQuery);

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -1,0 +1,3 @@
+setono_sylius_trustpilot:
+    blacklisted_customer:
+        blacklisted: Customer with email %email% was blacklisted

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -7,9 +7,11 @@ setono_sylius_trustpilot:
             template_id: Template id
     ui:
         afs_email: AFS email
+        blacklist_customer: Blacklist customer
         channel_configurations: Channel configurations
         edit_channel_configuration: Edit channel configuration
         failed: Failed
+        ineligible: Ineligible
         initial: Initial
         invitations: Invitations
         new_channel_configuration: New channel configuration

--- a/src/Resources/views/admin/block/_javascript_popup.html.twig
+++ b/src/Resources/views/admin/block/_javascript_popup.html.twig
@@ -1,0 +1,1 @@
+<script src="{{ asset('bundles/setonosyliustrustpilotplugin/setono-sylius-gift-card-popup.js') }}"></script>

--- a/src/Resources/views/admin/grid/action/blacklist_customer.html.twig
+++ b/src/Resources/views/admin/grid/action/blacklist_customer.html.twig
@@ -1,0 +1,6 @@
+{# todo use {% import '@SyliusUi/Macro/buttons.html.twig' as buttons %} in the future when you can add data-requires-confirmation to all buttons #}
+
+<a class="ui labeled icon red button" href="{{ path('setono_sylius_trustpilot_admin_blacklist_customer') }}" data-requires-confirmation>
+    <i class="icon ban"></i>
+    {{ action.label|trans }}
+</a>

--- a/src/Resources/views/admin/grid/label/invitation_state.html.twig
+++ b/src/Resources/views/admin/grid/label/invitation_state.html.twig
@@ -1,16 +1,24 @@
+{# @var \Setono\SyliusTrustpilotPlugin\Model\InvitationInterface data #}
 {%
     set viewOptions = {
         failed: { icon: 'ban', color: 'red' },
+        ineligible: { icon: 'ban', color: 'red' },
         initial: { icon: 'clock', color: 'gray' },
         pending: { icon: 'clock', color: 'olive' },
         processing: { icon: 'check', color: 'violet' },
         sent: { icon: 'check', color: 'green' },
 }
 %}
+{% set value = 'setono_sylius_trustpilot.ui.' ~ data.state %}
 
-{% set value = 'setono_sylius_trustpilot.ui.' ~ data %}
+{% set popupClass = '' %}
+{% set popupHtml = '' %}
+{% if data.ineligible or data.failed %}
+    {% set popupClass = ' invitation-popup' %}
+    {% set popupHtml = '<ul class="ui list"><li>' ~ data.processingErrors|join('</li><li>') ~ '</li></ul>' %}
+{% endif %}
 
-<span class="ui {{ viewOptions[data]['color'] }} label">
-    <i class="{{ viewOptions[data]['icon'] }} icon"></i>
+<span class="ui {{ viewOptions[data.state]['color'] }} label invitation-state{{ popupClass }}" data-html="{{ popupHtml|e('html_attr') }}">
+    <i class="{{ viewOptions[data.state]['icon'] }} icon"></i>
     {{ value|trans }}
 </span>

--- a/src/SetonoSyliusTrustpilotPlugin.php
+++ b/src/SetonoSyliusTrustpilotPlugin.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace Setono\SyliusTrustpilotPlugin;
 
+use Setono\SyliusTrustpilotPlugin\DependencyInjection\Compiler\RegisterInvitationEligibilityCheckersPass;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class SetonoSyliusTrustpilotPlugin extends AbstractResourceBundle
 {
     use SyliusPluginTrait;
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RegisterInvitationEligibilityCheckersPass());
+    }
 
     public function getSupportedDrivers(): array
     {

--- a/src/Workflow/InvitationWorkflow.php
+++ b/src/Workflow/InvitationWorkflow.php
@@ -13,6 +13,8 @@ final class InvitationWorkflow
 
     public const STATE_FAILED = 'failed';
 
+    public const STATE_INELIGIBLE = 'ineligible';
+
     public const STATE_INITIAL = 'initial';
 
     public const STATE_PENDING = 'pending';
@@ -29,6 +31,8 @@ final class InvitationWorkflow
 
     public const TRANSITION_FAIL = 'fail';
 
+    public const TRANSITION_FAIL_ELIGIBILITY_CHECK = 'fail_eligibility_check';
+
     private function __construct()
     {
     }
@@ -40,6 +44,7 @@ final class InvitationWorkflow
     {
         return [
             self::STATE_FAILED,
+            self::STATE_INELIGIBLE,
             self::STATE_INITIAL,
             self::STATE_PENDING,
             self::STATE_PROCESSING,
@@ -81,6 +86,7 @@ final class InvitationWorkflow
             new Transition(self::TRANSITION_START, self::STATE_INITIAL, self::STATE_PENDING),
             new Transition(self::TRANSITION_PROCESS, self::STATE_PENDING, self::STATE_PROCESSING),
             new Transition(self::TRANSITION_SEND, self::STATE_PROCESSING, self::STATE_SENT),
+            new Transition(self::TRANSITION_FAIL_ELIGIBILITY_CHECK, self::STATE_PROCESSING, self::STATE_INELIGIBLE),
             new Transition(self::TRANSITION_FAIL, self::getStates(), self::STATE_FAILED),
         ];
     }

--- a/tests/Application/config/routes/setono_sylius_trustpilot.yaml
+++ b/tests/Application/config/routes/setono_sylius_trustpilot.yaml
@@ -1,3 +1,2 @@
 setono_sylius_trustpilot_admin:
     resource: "@SetonoSyliusTrustpilotPlugin/Resources/config/routes.yaml"
-    prefix: /admin


### PR DESCRIPTION
Fixes #44 

This PR allows the administrator to blacklist an email.

It also adds an invitation eligibility checker which it uses to check if the email is blacklisted. This can be used for other purposes as well to check if an invitation is eligible to go out.

![image](https://user-images.githubusercontent.com/2412177/187146988-84805250-a25e-46d2-b6a8-9f897a1302e9.png)
